### PR TITLE
DP-2208 Retrieve errors messages from status API

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -25,6 +25,8 @@ provider:
     VERSION: ${self:custom.version}
     SERVICE_NAME: ${self:service}
     OKDATA_ENVIRONMENT: ${self:custom.okdataEnvironment.${self:provider.stage}, self:custom.okdataEnvironment.dev}
+    OKDATA_CLIENT_ID: ${self:service}
+    OKDATA_CLIENT_SECRET: ${ssm:/dataplatform/${self:service}/keycloak-client-secret~true}
 package:
   exclude:
     - '**/*'

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,3 +42,65 @@ def event(message):
     return {
         "Records": [{"EventSource": "aws:sns", "Sns": {"Message": json.dumps(message)}}]
     }
+
+
+@pytest.fixture
+def trace():
+    return [
+        {
+            "trace_event_status": "OK",
+            "operation": "upload",
+            "component": "data-uploader",
+            "s3_path": "raw/green/my-dataset/version=1/edition=20210809T122237/input_bad.json",
+            "user": "foo",
+            "start_time": "2021-08-09T12:22:41.743989+00:00",
+            "end_time": "2021-08-09T12:22:42.037621+00:00",
+            "trace_id": "my-dataset-7d5ca7f7-8ec1-6eaf-0cfd-72525a882417",
+            "trace_status": "STARTED",
+            "domain_id": "my-dataset/1",
+            "trace_event_id": "43c779d2-c94c-c964-e7b7-5f7d9589b7e5",
+            "domain": "dataset",
+        },
+        {
+            "trace_event_status": "OK",
+            "operation": "validate_input",
+            "component": "okdata-pipeline",
+            "meta": {
+                "git_rev": "main:bc7d428",
+                "function_name": "okdata-pipeline-dev-validate-json",
+                "function_version": "$LATEST",
+            },
+            "start_time": "2021-08-09T12:22:58.263737+00:00",
+            "end_time": "2021-08-09T12:22:58.356359+00:00",
+            "trace_id": "my-dataset-7d5ca7f7-8ec1-6eaf-0cfd-72525a882417",
+            "trace_status": "CONTINUE",
+            "errors": [
+                {
+                    "message": {
+                        "nb": "Opplastet JSON er ugyldig.",
+                        "en": "Uploaded JSON is invalid.",
+                    },
+                }
+            ],
+            "domain_id": "my-dataset/1",
+            "trace_event_id": "9bca5a33-c3c3-dc24-5804-d87388f220fa",
+            "duration": 92,
+            "domain": "dataset",
+        },
+        {
+            "trace_event_status": "FAILED",
+            "operation": "set_finished_status",
+            "component": "state-machine-event",
+            "trace_status": "FINISHED",
+            "meta": {
+                "git_rev": "main:784b55d",
+                "function_name": "state-machine-event-dev-act_on_queue",
+                "function_version": "$LATEST",
+            },
+            "start_time": "2021-08-09T12:22:59.906946+00:00",
+            "trace_event_id": "71d061f0-0014-0024-31f9-2dbe6b8e782d",
+            "end_time": "2021-08-09T12:22:59.907352+00:00",
+            "trace_id": "my-dataset-7d5ca7f7-8ec1-6eaf-0cfd-72525a882417",
+            "domain": "dataset",
+        },
+    ]


### PR DESCRIPTION
Retrieve error messages from the failed pipeline run from the status API to match what's shown in the web frontend.

Depends on https://github.com/oslokommune/dataplatform-config/pull/8.