### PR TITLE
DP-2252 Handle errors from status API better

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -104,3 +104,15 @@ def trace():
             "domain": "dataset",
         },
     ]
+
+
+@pytest.fixture
+def dataset():
+    return {
+        "contactPoint": {
+            "name": "Origo Dataplattform",
+            "email": "dataplattform@oslo.kommune.no",
+        },
+        "Type": "Dataset",
+        "Id": "dataplatform-probe",
+    }


### PR DESCRIPTION
Don't try too hard getting the status trace from the status API. If the status API is unavaiable or unable to look up the trace ID for some reason, just don't include the error messages, but send the email still.