### PR TITLE
Add trello action

### DIFF
--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,0 +1,19 @@
+name: GitHub Commit To Trello Comment
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: dalezak/github-commit-to-trello-card@e6a5ecb2a9c9ea5ac56234280324b2693bccbb8e
+        with:
+          trello-api-key: ${{ secrets.TRELLO_KEY }}
+          trello-auth-token: ${{ secrets.TRELLO_TOKEN }}
+          trello-board-id: ${{ secrets.TRELLO_BOARD }}
+          trello-card-action: "Attachment"
+          trello-list-name-commit: "Under arbeid"
+          trello-list-name-pr-open: "Review / Test"

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -1,4 +1,4 @@
-name: GitHub Commit To Trello Comment
+name: GitHub Commit To Trello
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Github action som legger til commits og PR til Trellokortet om du skriver `#trellokortnummeret` i commits
Den flytter også kortene basert på :
```
          trello-list-name-commit: "Under arbeid"
          trello-list-name-pr-open: "Review / Test"
```
Se in action:
https://trello.com/c/4slE0Sh3/39-github-action-to-attach-commits-and-pull-requests-to-trello-cards
