### PR TITLE
Upgrade okdata-aws to lose vulnerable dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,14 @@ botocore==1.31.85
     #   s3transfer
 certifi==2023.7.22
     # via requests
+cffi==1.16.0
+    # via cryptography
 charset-normalizer==2.1.0
     # via requests
-ecdsa==0.17.0
-    # via python-jose
+cryptography==42.0.5
+    # via jwcrypto
+deprecation==2.1.0
+    # via python-keycloak
 idna==3.7
     # via
     #   anyio
@@ -32,54 +36,46 @@ jmespath==1.0.1
     #   botocore
 jsonschema==4.6.1
     # via okdata-sdk
-okdata-aws==2.1.0
+jwcrypto==1.5.6
+    # via python-keycloak
+okdata-aws==4.1.0
     # via dataplatform-pipeline-alerts-email (setup.py)
-okdata-sdk==3.1.0
+okdata-sdk==3.1.1
     # via
     #   dataplatform-pipeline-alerts-email (setup.py)
     #   okdata-aws
-pyasn1==0.4.8
-    # via
-    #   python-jose
-    #   rsa
-pydantic==1.10.13
-    # via okdata-aws
-pyjwt==2.4.0
-    # via okdata-sdk
+packaging==24.0
+    # via deprecation
+pycparser==2.22
+    # via cffi
 pyrsistent==0.18.1
     # via jsonschema
 python-dateutil==2.8.2
     # via botocore
-python-jose==3.3.0
-    # via
-    #   okdata-sdk
-    #   python-keycloak
-python-keycloak==1.8.0
+python-keycloak==3.12.0
     # via okdata-sdk
 requests==2.32.0
     # via
     #   okdata-aws
     #   okdata-sdk
     #   python-keycloak
-rsa==4.8
-    # via python-jose
+    #   requests-toolbelt
+requests-toolbelt==1.0.0
+    # via python-keycloak
 s3transfer==0.6.0
     # via boto3
 six==1.16.0
-    # via
-    #   ecdsa
-    #   python-dateutil
+    # via python-dateutil
 sniffio==1.2.0
     # via anyio
-starlette==0.36.2
+starlette==0.37.2
     # via okdata-aws
 structlog==21.5.0
     # via okdata-aws
-typing-extensions==4.2.0
-    # via pydantic
+typing-extensions==4.11.0
+    # via jwcrypto
 urllib3==1.26.18
     # via
     #   botocore
     #   okdata-sdk
-    #   python-keycloak
     #   requests

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "boto3>=1.28.11",
-        "okdata-aws>=2.1,<3",
+        "okdata-aws>=4.1",
         "okdata-sdk",
     ],
 )


### PR DESCRIPTION
Remove dependency on the vulnerable ecdsa library by upgrading okdata-aws.